### PR TITLE
🔧 Fix: リリースワークフローの仮想環境使用を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,11 +131,11 @@ jobs:
         echo "🧪 Testing wheel installation in clean environment..."
         python -m venv test_env
         echo "📦 Installing dependencies in test environment..."
-        python -m pip install sphinx>=3.0 docutils>=0.18
+        test_env/bin/python -m pip install sphinx>=3.0 docutils>=0.18
         echo "📦 Installing our wheel..."
-        python -m pip install dist/*.whl
+        test_env/bin/python -m pip install dist/*.whl
         echo "🧪 Testing import in clean environment..."
-        python -c "import sphinxcontrib.jsontable; print(f'✅ Wheel installation test passed: v{sphinxcontrib.jsontable.__version__}'); print(f'📂 Package location: {sphinxcontrib.jsontable.__file__}')"
+        test_env/bin/python -c "import sphinxcontrib.jsontable; print(f'✅ Wheel installation test passed: v{sphinxcontrib.jsontable.__version__}'); print(f'📂 Package location: {sphinxcontrib.jsontable.__file__}')"
         echo "🧹 Cleaning up test environment..."
         rm -rf test_env
 


### PR DESCRIPTION
## 🔧 リリースワークフローの仮想環境使用を修正

### 問題の概要
リリースワークフローの「Test wheel installation in clean environment」ステップで、仮想環境を作成しているものの、実際にはグローバルPython環境でパッケージのインストールとテストが実行されていました。

### 原因
```yaml
# 仮想環境を作成
python -m venv test_env
# しかし、通常のpythonとpipを使用（グローバル環境）
python -m pip install sphinx>=3.0 docutils>=0.18
python -m pip install dist/*.whl
python -c "import sphinxcontrib.jsontable; ..."
```

### 修正内容
仮想環境のPythonとpipを明示的に使用するように修正：
```yaml
# 仮想環境のpythonとpipを使用
test_env/bin/python -m pip install sphinx>=3.0 docutils>=0.18
test_env/bin/python -m pip install dist/*.whl
test_env/bin/python -c "import sphinxcontrib.jsontable; ..."
```

### 影響範囲
- リリースワークフローの「Test wheel installation in clean environment」ステップのみ
- 他のステップには影響なし

### テスト
- この修正により、クリーンな環境でのホイールインストールテストが正しく動作します
- 依存関係の問題が解決され、リリースワークフローが成功するはずです

### 関連Issue/PR
- 失敗したワークフロー: https://github.com/sasakama-code/sphinxcontrib-jsontable/actions/runs/15387634065/job/43289621268