### PR TITLE
fix: Pythonバージョン要件の不一致を修正

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     package_data={
         "sphinxcontrib.jsontable": ["py.typed"],
     },
-    python_requires=">=3.10",
+    python_requires=">=3.9",
     install_requires=[
         "sphinx>=3.0",
         "docutils>=0.18",
@@ -84,6 +84,7 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
## 🐛 問題の説明

GitHub Actions のリリースワークフローでビルドが失敗していました。原因は以下の通りです：

1. **Pythonバージョン要件の不一致**
   - `pyproject.toml`: `requires-python = ">=3.9"`
   - `setup.py`: `python_requires=">=3.10"`
   
2. **欠落していたファイル**
   - `py.typed` ファイルがパッケージデータとして指定されていたが、実際には存在していなかった

## 🔧 修正内容

### 1. setup.py の修正
- `python_requires` を `">=3.10"` から `">=3.9"` に変更
- classifiers に `"Programming Language :: Python :: 3.9"` を追加

### 2. py.typed ファイルの追加
- `sphinxcontrib/jsontable/py.typed` ファイルを追加（型チェックサポートを示すマーカーファイル）

## ✅ 期待される効果

- Python 3.9 環境でのビルドとテストが正常に動作
- パッケージの配布時にエラーが発生しない
- pyproject.toml と setup.py の設定が一致し、一貫性のある動作

## 📝 確認事項

- [ ] Python 3.9 でのテストが通る
- [ ] ビルドプロセスが正常に完了する
- [ ] パッケージが正しくインストールできる