### PR TITLE
Fix Python syntax error in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,26 @@ jobs:
     - name: Run basic functionality test
       run: |
         echo "🧪 Running functionality test..."
-        python -c "exec('import tempfile, os\ntest_data = \"{\\\"name\\\": \\\"test\\\", \\\"value\\\": 123}\"\nwith tempfile.NamedTemporaryFile(mode=\"w\", suffix=\".json\", delete=False) as f:\n    f.write(test_data)\n    test_file = f.name\ntry:\n    from sphinxcontrib.jsontable.directives import JsonDataLoader, TableConverter, TableBuilder\n    loader = JsonDataLoader()\n    data = loader.parse_inline([test_data])\n    print(\"✅ JSON loading successful\")\n    converter = TableConverter()\n    table_data = converter.convert(data, include_header=True)\n    print(\"✅ Table conversion successful\")\n    builder = TableBuilder()\n    table_node = builder.build(table_data, has_header=True)\n    print(\"✅ Table building successful\")\n    print(\"🎉 All functionality tests passed!\")\nfinally:\n    os.unlink(test_file)')"
+        python -c "exec('import tempfile, os, json
+test_data_dict = {\"name\": \"test\", \"value\": 123}
+test_data = json.dumps(test_data_dict)
+with tempfile.NamedTemporaryFile(mode=\"w\", suffix=\".json\", delete=False) as f:
+    f.write(test_data)
+    test_file = f.name
+try:
+    from sphinxcontrib.jsontable.directives import JsonDataLoader, TableConverter, TableBuilder
+    loader = JsonDataLoader()
+    data = loader.parse_inline([test_data])
+    print(\"✅ JSON loading successful\")
+    converter = TableConverter()
+    table_data = converter.convert(data, include_header=True)
+    print(\"✅ Table conversion successful\")
+    builder = TableBuilder()
+    table_node = builder.build(table_data, has_header=True)
+    print(\"✅ Table building successful\")
+    print(\"🎉 All functionality tests passed!\")
+finally:
+    os.unlink(test_file)')"
 
     - name: Build source distribution and wheel
       run: |


### PR DESCRIPTION
# 修正内容

このプルリクエストは、リリースワークフローで発生していたPython構文エラーを修正します。

## 問題の概要

`.github/workflows/release.yml`の「Run basic functionality test」ステップで、JSON文字列のエスケープ処理が不適切なため、Python構文エラーが発生していました。

### エラー内容
```
test_data = "{"name": "test", "value": 123}"
                ^^^^
SyntaxError: invalid syntax
```

## 修正内容

JSON文字列を直接定義する代わりに、以下の方法を採用しました：

1. Pythonの辞書オブジェクトを作成
2. `json.dumps()`を使用してJSON文字列に変換

### 変更前
```python
test_data = "{\"name\": \"test\", \"value\": 123}"
```

### 変更後
```python
test_data_dict = {"name": "test", "value": 123}
test_data = json.dumps(test_data_dict)
```

## メリット

- 文字列リテラル内でのエスケープの複雑さを回避
- より読みやすく、保守しやすいコード
- 標準ライブラリのみを使用し、追加の依存関係なし

## テスト

この修正により、リリースワークフローが正常に実行されることを確認してください。

## 関連情報

詳細な調査結果については、調査報告書を参照してください。