### PR TITLE
fix: PyPI release failure due to license-file metadata error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,26 @@ jobs:
       with:
         python-version: ${{ env.PYTHON_VERSION }}
 
+    # ===============================
+    # Clean build artifacts (FIX for license-file error)
+    # ===============================
+    - name: Clean build artifacts
+      run: |
+        echo "🧹 Cleaning previous build artifacts..."
+        rm -rf dist/ build/ *.egg-info
+        find . -type d -name "__pycache__" -exec rm -rf {} +
+        find . -type d -name "*.egg-info" -exec rm -rf {} +
+        find . -type f -name "*.pyc" -delete
+        find . -type f -name "*.pyo" -delete
+        echo "✅ Cleanup completed"
+        
+        # Verify clean state
+        echo "📂 Verifying clean state:"
+        ls -la
+        [ ! -d "dist" ] && echo "✓ dist/ directory removed"
+        [ ! -d "build" ] && echo "✓ build/ directory removed"
+        find . -name "*.egg-info" -type d | wc -l | grep -q "^0$" && echo "✓ All .egg-info directories removed"
+
     - name: Debug environment and project structure
       run: |
         echo "🔍 Environment Debug Information"
@@ -107,26 +127,17 @@ jobs:
     - name: Run basic functionality test
       run: |
         echo "🧪 Running functionality test..."
-        python -c "exec('import tempfile, os, json\n\
-        test_data_dict = {\"name\": \"test\", \"value\": 123}\n\
-        test_data = json.dumps(test_data_dict)\n\
-        with tempfile.NamedTemporaryFile(mode=\"w\", suffix=\".json\", delete=False) as f:\n\
-            f.write(test_data)\n\
-            test_file = f.name\n\
-        try:\n\
-            from sphinxcontrib.jsontable.directives import JsonDataLoader, TableConverter, TableBuilder\n\
-            loader = JsonDataLoader()\n\
-            data = loader.parse_inline([test_data])\n\
-            print(\"✅ JSON loading successful\")\n\
-            converter = TableConverter()\n\
-            table_data = converter.convert(data, include_header=True)\n\
-            print(\"✅ Table conversion successful\")\n\
-            builder = TableBuilder()\n\
-            table_node = builder.build(table_data, has_header=True)\n\
-            print(\"✅ Table building successful\")\n\
-            print(\"🎉 All functionality tests passed!\")\n\
-        finally:\n\
-            os.unlink(test_file)')"
+        python -c "exec('import tempfile, os, json\n\n        test_data_dict = {\"name\": \"test\", \"value\": 123}\n\n        test_data = json.dumps(test_data_dict)\n\n        with tempfile.NamedTemporaryFile(mode=\"w\", suffix=\".json\", delete=False) as f:\n\n            f.write(test_data)\n\n            test_file = f.name\n\n        try:\n\n            from sphinxcontrib.jsontable.directives import JsonDataLoader, TableConverter, TableBuilder\n\n            loader = JsonDataLoader()\n\n            data = loader.parse_inline([test_data])\n\n            print(\"✅ JSON loading successful\")\n\n            converter = TableConverter()\n\n            table_data = converter.convert(data, include_header=True)\n\n            print(\"✅ Table conversion successful\")\n\n            builder = TableBuilder()\n\n            table_node = builder.build(table_data, has_header=True)\n\n            print(\"✅ Table building successful\")\n\n            print(\"🎉 All functionality tests passed!\")\n\n        finally:\n\n            os.unlink(test_file)')"
+
+    # ===============================
+    # Extra cleanup before build (FIX for license-file error)
+    # ===============================
+    - name: Final cleanup before build
+      run: |
+        echo "🧹 Final cleanup before build..."
+        rm -rf dist/ build/ *.egg-info
+        find . -type d -name "*.egg-info" -exec rm -rf {} +
+        echo "✅ Final cleanup completed"
 
     - name: Build source distribution and wheel
       run: |
@@ -226,13 +237,22 @@ jobs:
         name: python-package-distributions
         path: dist/
 
+    # ===============================
+    # Additional verification before PyPI upload (FIX)
+    # ===============================
     - name: Verify distributions before upload
       run: |
         echo "📋 Files to be uploaded to PyPI:"
         ls -la dist/
         echo "📊 Total files: $(ls -1 dist/ | wc -l)"
+        echo ""
+        echo "🔍 Installing twine for verification..."
         pip install twine
+        echo ""
+        echo "🔍 Running twine check..."
         python -m twine check dist/*
+        echo ""
+        echo "✅ All distribution files passed twine check"
 
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
# PyPI公開失敗の修正：license-fileメタデータエラーの解決

## 問題の概要
GitHub Actionsの`release.yml`ワークフローでPyPIへの公開が失敗しています。エラーログによると、配布メタデータの`license-file`フィールドが認識されないか不正な形式であることが原因です。

## エラーログ
```
2025-06-02T18:20:06.0212873Z Checking dist/sphinxcontrib_jsontable-0.1.0-py3-none-any.whl: 
[31mERROR   [0m InvalidDistribution: Invalid distribution metadata: unrecognized or malformed field 'license-file'
```

## 原因分析
現在のコードには直接`license-file`の記述は見当たらないため、以下が原因と考えられます：
- ビルドプロセス中に古いキャッシュや設定が使用されている
- `dist`ディレクトリに古いビルド成果物が残っている
- ビルドツールが内部的に誤った形式のメタデータを生成している

## 修正内容
このPRでは、以下の修正を行いました：

### 1. ビルド前のクリーンアップステップを追加
```yaml
- name: Clean build artifacts
  run: |
    echo "🧹 Cleaning previous build artifacts..."
    rm -rf dist/ build/ *.egg-info
    find . -type d -name "__pycache__" -exec rm -rf {} +
    find . -type d -name "*.egg-info" -exec rm -rf {} +
    find . -type f -name "*.pyc" -delete
    find . -type f -name "*.pyo" -delete
    echo "✅ Cleanup completed"
```

### 2. ビルド直前の最終クリーンアップステップを追加
ビルドの直前に再度クリーンアップを実行し、確実にクリーンな状態でビルドが行われるようにしました。

### 3. PyPI公開前の追加検証
PyPIへの公開前に`twine check`を実行し、配布ファイルの検証を強化しました。

## テスト方法
1. このPRをマージ後、新しいタグ（例：`v0.1.1`）を作成
2. GitHub ActionsのRelease workflowが正常に完了することを確認
3. PyPIへの公開が成功することを確認

## 今後の改善提案
- ビルドプロセスの自動化テストを強化
- CI/CDパイプラインに常にクリーンビルドステップを含める
- パッケージングの最新のベストプラクティスに従い、定期的に設定を見直す

## 関連情報
- [Python Packaging User Guide](https://packaging.python.org/)
- [setuptools documentation](https://setuptools.pypa.io/)
- [PEP 639 – Improving license clarity with better package metadata](https://www.python.org/dev/peps/pep-0639/)