### PR TITLE
fix: Resolve PyPI release error - malformed field 'license-file'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,12 +70,22 @@ jobs:
           echo "❌ sphinxcontrib directory not found"
         fi
 
-    - name: Install build dependencies
+    # ===============================
+    # Install build dependencies with specific versions (FIX)
+    # ===============================
+    - name: Install build dependencies with specific versions
       run: |
-        echo "📦 Installing build dependencies..."
+        echo "📦 Installing build dependencies with specific versions..."
         python -m pip install --upgrade pip
-        python -m pip install build twine
+        # Install specific versions to ensure compatibility
+        python -m pip install "setuptools>=77.0.0" "wheel>=0.44.0" "build>=1.2.2" "twine>=6.1.0"
         echo "✅ Build dependencies installed"
+        echo ""
+        echo "🔍 Verifying tool versions:"
+        python -c "import setuptools; print(f'setuptools: {setuptools.__version__}')"
+        python -c "import wheel; print(f'wheel: {wheel.__version__}')"
+        pip show build | grep Version
+        pip show twine | grep Version
 
     - name: Install package dependencies
       run: |
@@ -217,16 +227,48 @@ jobs:
         python -m build --verbose
         echo "✅ Build completed successfully"
 
-    - name: Verify distributions
+    # ===============================
+    # Enhanced verification for license metadata (FIX)
+    # ===============================
+    - name: Verify distributions and check metadata
       run: |
         echo "🔍 Verifying built distributions..."
-        python -m twine check dist/*
+        python -m twine check --strict dist/*
         echo "📋 Distribution files:"
         ls -la dist/
         echo "📊 Distribution details:"
         for file in dist/*; do
           echo "  📦 $file: $(wc -c < "$file") bytes"
         done
+        echo ""
+        echo "🔍 Checking wheel metadata for license-file issues:"
+        python << 'EOF'
+        import zipfile
+        import glob
+        
+        wheel_files = glob.glob("dist/*.whl")
+        if wheel_files:
+            wheel_file = wheel_files[0]
+            print(f"Checking {wheel_file}")
+            with zipfile.ZipFile(wheel_file, 'r') as zf:
+                metadata_files = [f for f in zf.namelist() if f.endswith('METADATA')]
+                if metadata_files:
+                    metadata_content = zf.read(metadata_files[0]).decode('utf-8')
+                    if 'license-file' in metadata_content.lower():
+                        print("⚠️  WARNING: Found 'license-file' in metadata")
+                        print("Content around license-file:")
+                        for line in metadata_content.split('\n'):
+                            if 'license' in line.lower():
+                                print(f"  {line}")
+                    else:
+                        print("✅ No 'license-file' field found in metadata")
+                    
+                    # Check metadata version
+                    for line in metadata_content.split('\n'):
+                        if line.startswith('Metadata-Version:'):
+                            print(f"✅ {line}")
+                            break
+        EOF
 
     - name: Test wheel installation in clean environment
       run: |
@@ -319,10 +361,10 @@ jobs:
         echo "📊 Total files: $(ls -1 dist/ | wc -l)"
         echo ""
         echo "🔍 Installing twine for verification..."
-        pip install twine
+        pip install "twine>=6.1.0"
         echo ""
-        echo "🔍 Running twine check..."
-        python -m twine check dist/*
+        echo "🔍 Running twine check with strict mode..."
+        python -m twine check --strict dist/*
         echo ""
         echo "✅ All distribution files passed twine check"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,8 +75,6 @@ Documentation = "https://github.com/sasakama-code/sphinxcontrib-jsontable#readme
 [tool.setuptools]
 zip-safe = false
 include-package-data = true
-# Explicitly control license file detection
-license-files = ["LICENSE"]
 
 [tool.setuptools.packages.find]
 # Explicitly specify the packages to include

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel"]
+requires = ["setuptools>=77.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -7,7 +7,8 @@ name = "sphinxcontrib-jsontable"
 version = "0.1.0"
 description = "Sphinx extension to render JSON data as tables"
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
+license-files = ["LICENSE"]
 dynamic = []
 authors = [{ name = "sasakama-code", email = "sasakamacode@gmail.com" }]
 maintainers = [{ name = "sasakama-code", email = "sasakamacode@gmail.com" }]
@@ -74,6 +75,8 @@ Documentation = "https://github.com/sasakama-code/sphinxcontrib-jsontable#readme
 [tool.setuptools]
 zip-safe = false
 include-package-data = true
+# Explicitly control license file detection
+license-files = ["LICENSE"]
 
 [tool.setuptools.packages.find]
 # Explicitly specify the packages to include

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
     "Environment :: Web Environment",
     "Framework :: Sphinx :: Extension",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,6 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     keywords=["sphinx", "json", "table", "documentation", "rst", "markdown"],
-    license="MIT",
+    # license field removed - now managed by pyproject.toml
     zip_safe=False,
 )


### PR DESCRIPTION
## 🔧 問題の修正

PyPIへのリリース時に発生していた `InvalidDistribution: Invalid distribution metadata: unrecognized or malformed field 'license-file'` エラーを修正しました。

## 🔍 根本原因

調査の結果、以下の問題が特定されました：

1. **setuptoolsの自動ライセンスファイル検出**：setuptoolsがLICENSEファイルを自動検出し、`License-File`メタデータフィールドを生成
2. **メタデータバージョンの不整合**：`License-File`フィールドはMetadata-Version 2.4（PEP 639）で導入されたが、setuptoolsは2.1を宣言していた
3. **設定の競合**：setup.pyとpyproject.tomlで異なるライセンス形式を使用していたことによる混乱

## ✨ 実施した修正

### 1. pyproject.tomlをPEP 639準拠に更新
- `license = { text = "MIT" }` （非推奨のテーブル形式）を `license = "MIT"` （SPDX文字列形式）に変更
- 明示的な `license-files = ["LICENSE"]` フィールドを追加
- setuptools要件を `>=77.0.0` に更新（PEP 639の適切なサポートのため）
- `[tool.setuptools]`セクションにも`license-files`を追加して明示的に制御

### 2. setup.pyからライセンスフィールドを削除
- setup()パラメータから `license="MIT"` を削除
- ライセンス情報はpyproject.tomlで一元管理するように変更
- これにより設定の競合を防止

### 3. GitHub Actionsワークフローを更新
- setuptools>=77.0.0とtwine>=6.1.0のバージョンを固定
- ビルドツールのバージョンチェックを追加
- ライセンスメタデータの問題を検出するための強化された検証を追加
- `twine check --strict`を使用した徹底的な検証
- 問題のあるフィールドを検出するためのwheelメタデータ検査を追加

## 🧪 テスト方法

修正を確認するには：

```bash
# クリーンビルド
rm -rf dist/ build/ *.egg-info
python -m build

# メタデータチェック
twine check --strict dist/*

# Wheelメタデータの検査
python -c "
import zipfile
with zipfile.ZipFile('dist/sphinxcontrib_jsontable-0.1.0-py3-none-any.whl', 'r') as zf:
    metadata = zf.read('sphinxcontrib_jsontable-0.1.0.dist-info/METADATA').decode('utf-8')
    print('License-File' in metadata)  # Should be False
"
```

## 📚 参考資料

- [PEP 639 – Improving License Clarity with Better Package Metadata](https://peps.python.org/pep-0639/)
- [setuptools issue #4759](https://github.com/pypa/setuptools/issues/4759)
- [packaging-problems issue #865](https://github.com/pypa/packaging-problems/issues/865)

## ✅ チェックリスト

- [x] pyproject.tomlをPEP 639準拠に更新
- [x] setup.pyからライセンスフィールドを削除
- [x] GitHub Actionsでツールバージョンを固定
- [x] メタデータ検証ステップを追加
- [x] すべての変更がコミットされている

この修正により、PyPIへのリリースが正常に実行されるようになります。