### PR TITLE
Fix CI: UV環境での一貫したpythonコマンド使用によるverify installationエラー解決

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
 
     - name: Verify installation
       run: |
-        python -c "import sphinxcontrib.jsontable; print('Package installed successfully')"
-        python -c "from sphinxcontrib.jsontable import __version__; print(f'Version: {__version__}')"
+        uv run python -c "import sphinxcontrib.jsontable; print('Package installed successfully')"
+        uv run python -c "from sphinxcontrib.jsontable import __version__; print(f'Version: {__version__}')"
 
     - name: Run ruff (linting)
       run: |


### PR DESCRIPTION
## 🛠️ CI修正: UV環境での一貫したコマンド使用

### 問題
PR#32のCIパイプラインでqualityフェーズの「verify installation」エラーが発生していました。

**根本原因:**
- `uv sync --dev`でuvパッケージマネージャーを使用して依存関係をインストール
- しかし、verification時に`python -c`コマンドを直接使用
- uvで管理される仮想環境にアクセスできないため、パッケージのimportに失敗

### 解決策

**修正内容:**
- `.github/workflows/ci.yml`のqualityジョブの「Verify installation」ステップを修正
- `python -c` → `uv run python -c` に変更
- uvで管理される仮想環境の一貫した使用を確保

### 変更の詳細

**修正前:**
```yaml
- name: Verify installation
  run: |
    python -c "import sphinxcontrib.jsontable; print('Package installed successfully')"
    python -c "from sphinxcontrib.jsontable import __version__; print(f'Version: {__version__}')"
```

**修正後:**
```yaml
- name: Verify installation
  run: |
    uv run python -c "import sphinxcontrib.jsontable; print('Package installed successfully')"
    uv run python -c "from sphinxcontrib.jsontable import __version__; print(f'Version: {__version__}')"
```

### 修正の影響

✅ **CI/CDパイプラインの安定性向上**
✅ **uvパッケージマネージャーとの整合性確保**  
✅ **PR#32のqualityフェーズエラー解決**
✅ **他のジョブとの一貫性確保**（buildやtestジョブは既に正しく`uv run`を使用）

### テスト計画

- [x] 修正内容のレビュー完了
- [ ] CI実行による動作確認
- [ ] 全ジョブ（quality, build, test, performance）の正常動作確認
- [ ] feature/rag-integrationブランチへのマージ

### チェックリスト

- [x] 問題の根本原因を特定
- [x] 適切な修正を実施
- [x] コミットメッセージに詳細説明を記載
- [x] issue#32に進捗報告
- [x] 他のジョブとの一貫性を確認

**関連issue:** #32
**修正対象:** CI/CDパイプライン
**緊急度:** 高（CI失敗によりPRマージが阻害）