### PR TITLE
Fix: Add psutil to test dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ test = [
     "pytest-cov>=5.0.0",
     "pytest-mock>=3.10.0",
     "pytest-benchmark>=5.1.0",
+    "psutil",
 ]
 all = ["sphinxcontrib-jsontable[excel,dev,docs,test]"]
 


### PR DESCRIPTION
The `test_performance_monitoring.py` module requires `psutil` for performance monitoring during tests. This commit adds `psutil` to the `[project.optional-dependencies.test]` in `pyproject.toml` to ensure it is installed when running tests, resolving the `ModuleNotFoundError`.

This change also ensures `psutil` is available in the `performance` CI job, as it installs the same set of test dependencies.