### PR TITLE
Identify and resolve CI errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -315,13 +315,13 @@ jobs:
       run: |
         source $HOME/.cargo/env
         source .venv/bin/activate
-        uv run python -m pytest tests/ --cov=sphinxcontrib.jsontable --cov-report=xml --cov-report=term-missing --cov-fail-under=10 -v -m "not benchmark"
+        python -m pytest tests/ --cov=sphinxcontrib.jsontable --cov-report=xml --cov-report=term-missing --cov-fail-under=10 -v -m "not benchmark"
 
     - name: Run tests (Windows)
       if: runner.os == 'Windows'
       run: |
         .venv\Scripts\activate
-        uv run python -m pytest tests/ --cov=sphinxcontrib.jsontable --cov-report=xml --cov-report=term-missing --cov-fail-under=10 -v -m "not benchmark"
+        python -m pytest tests/ --cov=sphinxcontrib.jsontable --cov-report=xml --cov-report=term-missing --cov-fail-under=10 -v -m "not benchmark"
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == '3.11' && matrix.os == 'ubuntu-latest'
@@ -375,13 +375,15 @@ jobs:
         source .venv/bin/activate
         echo "=== ベンチマークテスト実行 ==="
         echo "利用可能なベンチマークテスト数を確認中..."
-        BENCHMARK_COUNT=$(uv run python -m pytest tests/ -m benchmark --collect-only -q | grep "test session starts" -A 10 | grep -o "[0-9]\+ selected" | head -1 | cut -d' ' -f1 || echo "0")
+        BENCHMARK_COUNT=$(python -m pytest tests/ -m benchmark --collect-only -q 2>/dev/null | grep -c "test_" || echo "0")
         echo "発見されたベンチマークテスト数: $BENCHMARK_COUNT"
         if [ "$BENCHMARK_COUNT" -gt 0 ]; then
           echo "ベンチマークテストを実行します..."
-          uv run python -m pytest tests/ -m benchmark --benchmark-enable --benchmark-sort=mean --benchmark-json=benchmark.json -v --cov-fail-under=0
+          python -m pytest tests/ -m benchmark --benchmark-enable --benchmark-sort=mean --benchmark-json=benchmark.json -v --cov-fail-under=0 --tb=short
         else
           echo "⚠️ ベンチマークテストが見つかりませんでした。ベンチマーク実行をスキップします。"
+          echo "デバッグ情報："
+          python -m pytest tests/ -m benchmark --collect-only -v
         fi
       continue-on-error: true  # ベンチマークは失敗してもCI全体は通す
 
@@ -391,14 +393,17 @@ jobs:
         .venv\Scripts\activate
         echo "=== ベンチマークテスト実行 ==="
         echo "利用可能なベンチマークテスト数を確認中..."
-        for /f %%i in ('uv run python -m pytest tests/ -m benchmark --collect-only -q 2^>nul ^| findstr /C:"selected" 2^>nul') do set BENCHMARK_COUNT=%%i
-        if not defined BENCHMARK_COUNT set BENCHMARK_COUNT=0
+        python -m pytest tests/ -m benchmark --collect-only -q 2>nul | find /c "test_" > temp_count.txt || echo 0 > temp_count.txt
+        set /p BENCHMARK_COUNT=<temp_count.txt
+        del temp_count.txt
         echo 発見されたベンチマークテスト数: %BENCHMARK_COUNT%
         if %BENCHMARK_COUNT% gtr 0 (
           echo ベンチマークテストを実行します...
-          uv run python -m pytest tests/ -m benchmark --benchmark-enable --benchmark-sort=mean --benchmark-json=benchmark.json -v --cov-fail-under=0
+          python -m pytest tests/ -m benchmark --benchmark-enable --benchmark-sort=mean --benchmark-json=benchmark.json -v --cov-fail-under=0 --tb=short
         ) else (
           echo ⚠️ ベンチマークテストが見つかりませんでした。ベンチマーク実行をスキップします。
+          echo デバッグ情報：
+          python -m pytest tests/ -m benchmark --collect-only -v
         )
       continue-on-error: true  # ベンチマークは失敗してもCI全体は通す
 
@@ -411,14 +416,16 @@ jobs:
         source .venv/bin/activate
         echo "=== パフォーマンステスト実行 ==="
         echo "利用可能なパフォーマンステスト数を確認中..."
-        PERFORMANCE_COUNT=$(uv run python -m pytest tests/ -m performance --collect-only -q | grep "test session starts" -A 10 | grep -o "[0-9]\+ selected" | head -1 | cut -d' ' -f1 || echo "0")
+        PERFORMANCE_COUNT=$(python -m pytest tests/ -m performance --collect-only -q 2>/dev/null | grep -c "test_" || echo "0")
         echo "発見されたパフォーマンステスト数: $PERFORMANCE_COUNT"
         if [ "$PERFORMANCE_COUNT" -gt 0 ]; then
           echo "パフォーマンステストを実行します..."
-          uv run python -m pytest tests/ -m performance -v --override-ini addopts=""
+          python -m pytest tests/ -m performance -v --override-ini addopts="" --tb=short
         else
           echo "❌ パフォーマンステストが見つかりませんでした。"
           echo "パフォーマンステストの@pytest.mark.performanceマーカーを確認してください。"
+          echo "デバッグ情報："
+          python -m pytest tests/ -m performance --collect-only -v
           exit 1
         fi
 
@@ -430,15 +437,18 @@ jobs:
         .venv\Scripts\activate
         echo "=== パフォーマンステスト実行 ==="
         echo "利用可能なパフォーマンステスト数を確認中..."
-        for /f %%i in ('uv run python -m pytest tests/ -m performance --collect-only -q 2^>nul ^| findstr /C:"selected" 2^>nul') do set PERFORMANCE_COUNT=%%i
-        if not defined PERFORMANCE_COUNT set PERFORMANCE_COUNT=0
+        python -m pytest tests/ -m performance --collect-only -q 2>nul | find /c "test_" > temp_count.txt || echo 0 > temp_count.txt
+        set /p PERFORMANCE_COUNT=<temp_count.txt
+        del temp_count.txt
         echo 発見されたパフォーマンステスト数: %PERFORMANCE_COUNT%
         if %PERFORMANCE_COUNT% gtr 0 (
           echo パフォーマンステストを実行します...
-          uv run python -m pytest tests/ -m performance -v --override-ini addopts=""
+          python -m pytest tests/ -m performance -v --override-ini addopts="" --tb=short
         ) else (
           echo ❌ パフォーマンステストが見つかりませんでした。
           echo パフォーマンステストの@pytest.mark.performanceマーカーを確認してください。
+          echo デバッグ情報：
+          python -m pytest tests/ -m performance --collect-only -v
           exit 1
         )
 

--- a/tests/benchmark/test_benchmark_core.py
+++ b/tests/benchmark/test_benchmark_core.py
@@ -117,6 +117,7 @@ class TestBenchmarkCore:
     @pytest.mark.benchmark
     def test_json_data_creation_benchmark(self, benchmark):
         """JSONデータ作成のベンチマーク."""
+
         def json_data_creation():
             """ベンチマーク対象の処理."""
             return [{"id": i, "name": f"Item{i}", "value": i * 10} for i in range(100)]
@@ -127,6 +128,7 @@ class TestBenchmarkCore:
     @pytest.mark.benchmark
     def test_table_data_conversion_benchmark(self, benchmark):
         """テーブルデータ変換のベンチマーク."""
+
         def table_data_conversion():
             """ベンチマーク対象の処理."""
             headers = ["ID", "Name", "Value"]


### PR DESCRIPTION
<!-- Refactor CI workflow to use direct `python` execution and simplify test counting logic to fix CI failures on Ubuntu 24.04. -->

<!-- The previous CI setup encountered issues on Ubuntu 24.04 due to PEP 668 restrictions on system Python, leading to `uv run python` failures. Additionally, the complex string parsing for counting benchmark and performance tests was unreliable, causing 'tests not found' errors. This PR addresses these by directly invoking `python` within the activated virtual environment and simplifying the test counting logic. -->