### PR TITLE
feat: implement column customization feature (Issue #48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Against this backdrop, sphinxcontrib-jsontable was developed to directly embed s
 * Row limiting for large datasets
 * Custom file encoding support
 * Responsive table formatting
+* **Column Customization**: Show/hide columns, custom ordering, and width control
 
 🔒 **Robust & Safe**
 * Path traversal protection
@@ -193,6 +194,18 @@ Financial Report
    :limit: 100
 ```
 
+**Column Customization:**
+```rst
+Employee Report (Customized View)
+=================================
+
+.. jsontable:: data/employees.json
+   :columns: name,department,email
+   :column-order: department,name,email
+   :column-widths: 2,3,4
+   :hide-columns: id,created_at
+```
+
 **In Markdown (with myst-parser):**
 ````markdown
 # User Database
@@ -334,6 +347,10 @@ sphinxcontrib-jsontable provides comprehensive Excel file support with advanced 
 | `merge-headers` | string | Multi-row header merging | `:merge-headers: true` |
 | `json-cache` | flag | Enable caching | `:json-cache:` |
 | `auto-header` | flag | Auto header detection | `:auto-header:` |
+| `columns` | string | Show specific columns | `:columns: name,age,city` |
+| `column-order` | string | Custom column order | `:column-order: city,name,age` |
+| `column-widths` | string | Column width ratios | `:column-widths: 2,1,3` |
+| `hide-columns` | string | Hide specific columns | `:hide-columns: id,timestamp` |
 
 ### Complete Directive Options
 
@@ -354,6 +371,10 @@ The `jsontable` directive supports all these options for maximum flexibility:
    :merge-cells: expand  # Merged cell processing (expand/ignore/first-value)
    :merge-headers:       # Hierarchical header merging
    :json-cache:          # Enable JSON caching for performance
+   :columns: name,age    # Show only specified columns (comma-separated)
+   :column-order: age,name  # Custom column order (comma-separated)
+   :column-widths: 2,3,1    # Column width ratios (comma-separated integers)
+   :hide-columns: id,timestamp  # Hide specific columns (comma-separated)
 ```
 
 ## Comprehensive Usage Guide

--- a/examples/column_customization_examples.rst
+++ b/examples/column_customization_examples.rst
@@ -1,0 +1,110 @@
+Column Customization Examples
+============================
+
+This document demonstrates the new column customization features added in Issue #48.
+
+Basic Column Selection
+----------------------
+
+You can specify which columns to display using the `columns` option:
+
+.. jsontable::
+   :columns: name,age,city
+
+   [
+     {"name": "Alice", "age": 25, "city": "Tokyo", "country": "Japan", "id": 1},
+     {"name": "Bob", "age": 30, "city": "NYC", "country": "USA", "id": 2},
+     {"name": "Carol", "age": 28, "city": "London", "country": "UK", "id": 3}
+   ]
+
+Column Hiding
+-------------
+
+You can hide specific columns using the `hide-columns` option:
+
+.. jsontable::
+   :hide-columns: id,country
+
+   [
+     {"name": "Alice", "age": 25, "city": "Tokyo", "country": "Japan", "id": 1},
+     {"name": "Bob", "age": 30, "city": "NYC", "country": "USA", "id": 2},
+     {"name": "Carol", "age": 28, "city": "London", "country": "UK", "id": 3}
+   ]
+
+Column Ordering
+---------------
+
+You can specify the order of columns using the `column-order` option:
+
+.. jsontable::
+   :column-order: name,city,age
+
+   [
+     {"name": "Alice", "age": 25, "city": "Tokyo", "country": "Japan"},
+     {"name": "Bob", "age": 30, "city": "NYC", "country": "USA"},
+     {"name": "Carol", "age": 28, "city": "London", "country": "UK"}
+   ]
+
+Column Widths
+-------------
+
+You can specify custom column widths using the `column-widths` option:
+
+.. jsontable::
+   :column-widths: 3,1,2
+   :columns: name,age,city
+
+   [
+     {"name": "Alice", "age": 25, "city": "Tokyo"},
+     {"name": "Bob", "age": 30, "city": "NYC"},
+     {"name": "Carol", "age": 28, "city": "London"}
+   ]
+
+Combined Features
+-----------------
+
+You can combine multiple column customization options:
+
+.. jsontable::
+   :columns: name,age,city,country
+   :hide-columns: age
+   :column-order: country,city,name
+   :column-widths: 2,2,3
+
+   [
+     {"name": "Alice", "age": 25, "city": "Tokyo", "country": "Japan", "id": 1, "timestamp": "2024-01-01"},
+     {"name": "Bob", "age": 30, "city": "NYC", "country": "USA", "id": 2, "timestamp": "2024-01-02"},
+     {"name": "Carol", "age": 28, "city": "London", "country": "UK", "id": 3, "timestamp": "2024-01-03"}
+   ]
+
+This will:
+1. Start with specified columns: name, age, city, country
+2. Hide the age column: name, city, country
+3. Reorder to: country, city, name
+4. Apply widths [2, 2, 3] to the final columns
+
+2D Array Support
+----------------
+
+Column customization also works with 2D arrays:
+
+.. jsontable::
+   :column-order: City,Name,Age
+   :column-widths: 2,3,1
+
+   [
+     ["Name", "Age", "City"],
+     ["Alice", "25", "Tokyo"],
+     ["Bob", "30", "NYC"],
+     ["Carol", "28", "London"]
+   ]
+
+File-based Data
+---------------
+
+Column customization works with file-based data as well:
+
+.. jsontable:: data/sample_users.json
+   :columns: name,email,city
+   :column-order: city,name,email
+   :column-widths: 2,3,4

--- a/sphinxcontrib/jsontable/directives/directive_core.py
+++ b/sphinxcontrib/jsontable/directives/directive_core.py
@@ -111,7 +111,9 @@ class JsonTableDirective(BaseDirective):
         )
 
         # Initialize JSON processor
-        self.json_processor = JsonProcessor(base_path=self.base_path, encoding=encoding)
+        self.json_processor = JsonProcessor(
+            base_path=self.base_path, encoding=encoding
+        )
 
         # Initialize JsonDataLoader for backward compatibility
         from . import JsonDataLoader
@@ -129,7 +131,9 @@ class JsonTableDirective(BaseDirective):
                 logger.debug("Excel processor initialized successfully")
             except ImportError:
                 self.excel_processor = None
-                logger.warning("Excel processor unavailable despite EXCEL_SUPPORT=True")
+                logger.warning(
+                    "Excel processor unavailable despite EXCEL_SUPPORT=True"
+                )
         else:
             self.excel_processor = None
 
@@ -257,7 +261,9 @@ class JsonTableDirective(BaseDirective):
             column_config = self._extract_column_config()
 
             # Step 4: Convert to table format with column configuration
-            table_data = self.table_converter.convert(json_data, column_config=column_config)
+            table_data = self.table_converter.convert(
+                json_data, column_config=column_config
+            )
 
             # Step 5: Apply directive options to table data
             if limit is not None:
@@ -269,7 +275,9 @@ class JsonTableDirective(BaseDirective):
 
             # Step 6: Build docutils table with column widths
             column_widths = column_config.get("column_widths")
-            table_nodes = self.table_builder.build_table(table_data, column_widths=column_widths)
+            table_nodes = self.table_builder.build_table(
+                table_data, column_widths=column_widths
+            )
 
             logger.info("JsonTableDirective execution completed successfully")
             return table_nodes
@@ -376,7 +384,7 @@ class JsonTableDirective(BaseDirective):
 
     def _extract_column_config(self) -> dict[str, Any]:
         """Extract column customization configuration from directive options.
-        
+
         Returns:
             Dictionary containing column configuration with keys:
             - visible_columns: List of column names to display
@@ -385,7 +393,7 @@ class JsonTableDirective(BaseDirective):
             - hidden_columns: List of column names to hide
         """
         column_config = {}
-        
+
         # Parse columns option (comma-separated list of column names)
         if "columns" in self.options:
             columns_str = self.options["columns"].strip()
@@ -393,7 +401,7 @@ class JsonTableDirective(BaseDirective):
                 column_config["visible_columns"] = [
                     col.strip() for col in columns_str.split(",") if col.strip()
                 ]
-        
+
         # Parse column-order option
         if "column-order" in self.options:
             order_str = self.options["column-order"].strip()
@@ -401,18 +409,20 @@ class JsonTableDirective(BaseDirective):
                 column_config["column_order"] = [
                     col.strip() for col in order_str.split(",") if col.strip()
                 ]
-        
+
         # Parse column-widths option
         if "column-widths" in self.options:
             widths_str = self.options["column-widths"].strip()
             if widths_str:
                 try:
                     column_config["column_widths"] = [
-                        int(width.strip()) for width in widths_str.split(",") if width.strip()
+                        int(width.strip())
+                        for width in widths_str.split(",")
+                        if width.strip()
                     ]
                 except ValueError as e:
                     logger.warning(f"Invalid column-widths format: {e}")
-        
+
         # Parse hide-columns option
         if "hide-columns" in self.options:
             hide_str = self.options["hide-columns"].strip()
@@ -420,7 +430,7 @@ class JsonTableDirective(BaseDirective):
                 column_config["hidden_columns"] = [
                     col.strip() for col in hide_str.split(",") if col.strip()
                 ]
-        
+
         logger.debug(f"Extracted column config: {column_config}")
         return column_config
 

--- a/sphinxcontrib/jsontable/directives/table_builder.py
+++ b/sphinxcontrib/jsontable/directives/table_builder.py
@@ -103,7 +103,10 @@ class TableBuilder:
         )
 
     def build_table(
-        self, table_data: TableData, has_header: bool = True, column_widths: list[int] | None = None
+        self,
+        table_data: TableData,
+        has_header: bool = True,
+        column_widths: list[int] | None = None,
     ) -> list[nodes.table]:
         """
         Build enterprise-grade docutils.nodes.table from 2D list of strings.
@@ -189,7 +192,10 @@ class TableBuilder:
         return table_nodes[0]
 
     def _build_table_internal(
-        self, table_data: TableData, has_header: bool = True, column_widths: list[int] | None = None
+        self,
+        table_data: TableData,
+        has_header: bool = True,
+        column_widths: list[int] | None = None,
     ) -> nodes.table:
         """
         Internal method to build docutils table structure.
@@ -228,7 +234,9 @@ class TableBuilder:
         table += tgroup
         return table
 
-    def _create_table_structure(self, cols: int, column_widths: list[int] | None = None) -> nodes.table:
+    def _create_table_structure(
+        self, cols: int, column_widths: list[int] | None = None
+    ) -> nodes.table:
         """
         Create a table structure with given number of columns.
 
@@ -249,7 +257,9 @@ class TableBuilder:
 
         return table
 
-    def _create_colspec_nodes(self, col_count: int, column_widths: list[int] | None = None) -> list[nodes.colspec]:
+    def _create_colspec_nodes(
+        self, col_count: int, column_widths: list[int] | None = None
+    ) -> list[nodes.colspec]:
         """
         Create column specification nodes.
 
@@ -274,9 +284,9 @@ class TableBuilder:
                 logger.debug(f"Setting column {i} width to {width}")
             else:
                 width = 1
-            
+
             colspecs.append(nodes.colspec(colwidth=width))
-        
+
         return colspecs
 
     def _add_header(self, table: nodes.table, header_data: list[str]) -> None:

--- a/sphinxcontrib/jsontable/directives/table_converter.py
+++ b/sphinxcontrib/jsontable/directives/table_converter.py
@@ -369,48 +369,52 @@ class TableConverter:
         
         # Create column indices to keep
         column_indices = list(range(len(header_row)))
-        
+
         # Apply visible_columns filter (by header names)
         if "visible_columns" in column_config:
             visible_columns = column_config["visible_columns"]
-            column_indices = [i for i, header in enumerate(header_row) if header in visible_columns]
-        
+            column_indices = [
+                i for i, header in enumerate(header_row) if header in visible_columns
+            ]
+
         # Apply hidden_columns filter (by header names)
         if "hidden_columns" in column_config:
             hidden_columns = column_config["hidden_columns"]
-            column_indices = [i for i, header in enumerate(header_row) if header not in hidden_columns]
-        
+            column_indices = [
+                i for i, header in enumerate(header_row) if header not in hidden_columns
+            ]
+
         # Apply column_order (by header names)
         if "column_order" in column_config:
             column_order = column_config["column_order"]
             ordered_indices = []
-            
+
             # First, add columns in specified order
             for ordered_header in column_order:
                 for i, header in enumerate(header_row):
                     if header == ordered_header and i in column_indices:
                         ordered_indices.append(i)
                         break
-            
+
             # Then, add any remaining columns not in the order specification
             for i in column_indices:
                 if i not in ordered_indices:
                     ordered_indices.append(i)
-            
+
             column_indices = ordered_indices
-        
+
         # Apply column filtering to all rows
         result = []
         for row in data:
             filtered_row = [row[i] if i < len(row) else "" for i in column_indices]
             result.append(filtered_row)
-        
+
         logger.debug(
             f"Applied column config to 2D array: {len(data[0])} -> "
             f"{len(result[0])} columns"
         )
         return result
-    
+
     def _safe_str(self, value) -> str:
         """Safely convert value to string."""
         if value is None:

--- a/sphinxcontrib/jsontable/directives/table_converter.py
+++ b/sphinxcontrib/jsontable/directives/table_converter.py
@@ -80,7 +80,7 @@ class TableConverter:
             f"TableConverter initialized with max_rows={self.max_rows}, performance_mode={performance_mode}"
         )
 
-    def convert(self, data: JsonData, include_header: bool | None = None) -> TableData:
+    def convert(self, data: JsonData, include_header: bool | None = None, column_config: dict[str, Any] | None = None) -> TableData:
         """
         Convert JSON data to tabular format with comprehensive validation and optimization.
 
@@ -172,9 +172,9 @@ class TableConverter:
 
         # Route to appropriate conversion method
         if isinstance(data, dict):
-            result = self._convert_single_object(data)
+            result = self._convert_single_object(data, column_config)
         elif isinstance(data, list):
-            result = self._convert_array(data)
+            result = self._convert_array(data, column_config)
         else:
             raise JsonTableError(INVALID_JSON_DATA_ERROR)
 
@@ -205,29 +205,34 @@ class TableConverter:
         logger.debug(f"Conversion completed: {len(result)} rows")
         return result
 
-    def _convert_single_object(self, data: dict) -> TableData:
+    def _convert_single_object(self, data: dict, column_config: dict[str, Any] | None = None) -> TableData:
         """Convert single object to table format."""
         if not data:
             return []
 
         keys = sorted(data.keys())
+        
+        # Apply column configuration
+        if column_config:
+            keys = self._apply_column_config(keys, column_config)
+        
         header = keys
         values = [self._safe_str(data.get(key, "")) for key in keys]
 
         return [header, values]
 
-    def _convert_array(self, data: list) -> TableData:
+    def _convert_array(self, data: list, column_config: dict[str, Any] | None = None) -> TableData:
         """Convert array to table format."""
         if not data:
             return []
 
         # Check if it's an array of objects
         if data and isinstance(data[0], dict):
-            return self._convert_object_array(data)
+            return self._convert_object_array(data, column_config)
         else:
-            return self._convert_2d_array(data)
+            return self._convert_2d_array(data, column_config)
 
-    def _convert_object_array(self, data: list) -> TableData:
+    def _convert_object_array(self, data: list, column_config: dict[str, Any] | None = None) -> TableData:
         """Convert array of objects to table format."""
         if not data:
             return []
@@ -240,6 +245,10 @@ class TableConverter:
 
         # Sort keys for consistent output
         sorted_keys = sorted(all_keys)
+        
+        # Apply column configuration
+        if column_config:
+            sorted_keys = self._apply_column_config(sorted_keys, column_config)
 
         # Build header row
         result = [sorted_keys]
@@ -254,7 +263,7 @@ class TableConverter:
 
         return result
 
-    def _convert_2d_array(self, data: list) -> TableData:
+    def _convert_2d_array(self, data: list, column_config: dict[str, Any] | None = None) -> TableData:
         """Convert 2D array to table format."""
         if not data:
             return []
@@ -275,8 +284,113 @@ class TableConverter:
 
             result.append(normalized_row)
 
+        # Apply column configuration to 2D array
+        if column_config and result:
+            result = self._apply_column_config_to_2d_array(result, column_config)
+
         return result
 
+    def _apply_column_config(self, keys: list[str], column_config: dict[str, Any]) -> list[str]:
+        """Apply column configuration to column keys for object arrays.
+        
+        Args:
+            keys: List of column keys (sorted)
+            column_config: Column configuration dictionary
+            
+        Returns:
+            List of column keys after applying configuration
+        """
+        result_keys = list(keys)
+        
+        # Apply visible_columns filter
+        if "visible_columns" in column_config:
+            visible_columns = column_config["visible_columns"]
+            result_keys = [key for key in result_keys if key in visible_columns]
+        
+        # Apply hidden_columns filter
+        if "hidden_columns" in column_config:
+            hidden_columns = column_config["hidden_columns"]
+            result_keys = [key for key in result_keys if key not in hidden_columns]
+        
+        # Apply column_order
+        if "column_order" in column_config:
+            column_order = column_config["column_order"]
+            ordered_keys = []
+            
+            # First, add columns in specified order
+            for ordered_key in column_order:
+                if ordered_key in result_keys:
+                    ordered_keys.append(ordered_key)
+            
+            # Then, add any remaining columns not in the order specification
+            for key in result_keys:
+                if key not in ordered_keys:
+                    ordered_keys.append(key)
+            
+            result_keys = ordered_keys
+        
+        logger.debug(f"Applied column config: {keys} -> {result_keys}")
+        return result_keys
+    
+    def _apply_column_config_to_2d_array(self, data: TableData, column_config: dict[str, Any]) -> TableData:
+        """Apply column configuration to 2D array data.
+        
+        Args:
+            data: 2D array table data
+            column_config: Column configuration dictionary
+            
+        Returns:
+            2D array with column configuration applied
+        """
+        if not data:
+            return data
+        
+        # For 2D arrays, we need to work with column indices
+        # We assume the first row contains headers if available
+        header_row = data[0]
+        data_rows = data[1:] if len(data) > 1 else []
+        
+        # Create column indices to keep
+        column_indices = list(range(len(header_row)))
+        
+        # Apply visible_columns filter (by header names)
+        if "visible_columns" in column_config:
+            visible_columns = column_config["visible_columns"]
+            column_indices = [i for i, header in enumerate(header_row) if header in visible_columns]
+        
+        # Apply hidden_columns filter (by header names)
+        if "hidden_columns" in column_config:
+            hidden_columns = column_config["hidden_columns"]
+            column_indices = [i for i, header in enumerate(header_row) if header not in hidden_columns]
+        
+        # Apply column_order (by header names)
+        if "column_order" in column_config:
+            column_order = column_config["column_order"]
+            ordered_indices = []
+            
+            # First, add columns in specified order
+            for ordered_header in column_order:
+                for i, header in enumerate(header_row):
+                    if header == ordered_header and i in column_indices:
+                        ordered_indices.append(i)
+                        break
+            
+            # Then, add any remaining columns not in the order specification
+            for i in column_indices:
+                if i not in ordered_indices:
+                    ordered_indices.append(i)
+            
+            column_indices = ordered_indices
+        
+        # Apply column filtering to all rows
+        result = []
+        for row in data:
+            filtered_row = [row[i] if i < len(row) else "" for i in column_indices]
+            result.append(filtered_row)
+        
+        logger.debug(f"Applied column config to 2D array: {len(data[0])} -> {len(result[0])} columns")
+        return result
+    
     def _safe_str(self, value) -> str:
         """Safely convert value to string."""
         if value is None:

--- a/sphinxcontrib/jsontable/directives/table_converter.py
+++ b/sphinxcontrib/jsontable/directives/table_converter.py
@@ -308,65 +308,65 @@ class TableConverter:
         self, keys: list[str], column_config: dict[str, Any]
     ) -> list[str]:
         """Apply column configuration to column keys for object arrays.
-        
+
         Args:
             keys: List of column keys (sorted)
             column_config: Column configuration dictionary
-            
+
         Returns:
             List of column keys after applying configuration
         """
         result_keys = list(keys)
-        
+
         # Apply visible_columns filter
         if "visible_columns" in column_config:
             visible_columns = column_config["visible_columns"]
             result_keys = [key for key in result_keys if key in visible_columns]
-        
+
         # Apply hidden_columns filter
         if "hidden_columns" in column_config:
             hidden_columns = column_config["hidden_columns"]
             result_keys = [key for key in result_keys if key not in hidden_columns]
-        
+
         # Apply column_order
         if "column_order" in column_config:
             column_order = column_config["column_order"]
             ordered_keys = []
-            
+
             # First, add columns in specified order
             for ordered_key in column_order:
                 if ordered_key in result_keys:
                     ordered_keys.append(ordered_key)
-            
+
             # Then, add any remaining columns not in the order specification
             for key in result_keys:
                 if key not in ordered_keys:
                     ordered_keys.append(key)
-            
+
             result_keys = ordered_keys
 
         logger.debug(f"Applied column config: {keys} -> {result_keys}")
         return result_keys
-    
+
     def _apply_column_config_to_2d_array(
         self, data: TableData, column_config: dict[str, Any]
     ) -> TableData:
         """Apply column configuration to 2D array data.
-        
+
         Args:
             data: 2D array table data
             column_config: Column configuration dictionary
-            
+
         Returns:
             2D array with column configuration applied
         """
         if not data:
             return data
-        
+
         # For 2D arrays, we need to work with column indices
         # We assume the first row contains headers if available
         header_row = data[0]
-        
+
         # Create column indices to keep
         column_indices = list(range(len(header_row)))
 
@@ -374,14 +374,18 @@ class TableConverter:
         if "visible_columns" in column_config:
             visible_columns = column_config["visible_columns"]
             column_indices = [
-                i for i, header in enumerate(header_row) if header in visible_columns
+                i
+                for i, header in enumerate(header_row)
+                if header in visible_columns
             ]
 
         # Apply hidden_columns filter (by header names)
         if "hidden_columns" in column_config:
             hidden_columns = column_config["hidden_columns"]
             column_indices = [
-                i for i, header in enumerate(header_row) if header not in hidden_columns
+                i
+                for i, header in enumerate(header_row)
+                if header not in hidden_columns
             ]
 
         # Apply column_order (by header names)
@@ -406,7 +410,9 @@ class TableConverter:
         # Apply column filtering to all rows
         result = []
         for row in data:
-            filtered_row = [row[i] if i < len(row) else "" for i in column_indices]
+            filtered_row = [
+                row[i] if i < len(row) else "" for i in column_indices
+            ]
             result.append(filtered_row)
 
         logger.debug(

--- a/sphinxcontrib/jsontable/directives/table_converter.py
+++ b/sphinxcontrib/jsontable/directives/table_converter.py
@@ -348,7 +348,6 @@ class TableConverter:
         # For 2D arrays, we need to work with column indices
         # We assume the first row contains headers if available
         header_row = data[0]
-        data_rows = data[1:] if len(data) > 1 else []
         
         # Create column indices to keep
         column_indices = list(range(len(header_row)))

--- a/sphinxcontrib/jsontable/directives/table_converter.py
+++ b/sphinxcontrib/jsontable/directives/table_converter.py
@@ -77,10 +77,16 @@ class TableConverter:
         self.max_rows = max_rows or DEFAULT_MAX_ROWS
         self.performance_mode = performance_mode
         logger.debug(
-            f"TableConverter initialized with max_rows={self.max_rows}, performance_mode={performance_mode}"
+            f"TableConverter initialized with max_rows={self.max_rows}, "
+            f"performance_mode={performance_mode}"
         )
 
-    def convert(self, data: JsonData, include_header: bool | None = None, column_config: dict[str, Any] | None = None) -> TableData:
+    def convert(
+        self,
+        data: JsonData,
+        include_header: bool | None = None,
+        column_config: dict[str, Any] | None = None,
+    ) -> TableData:
         """
         Convert JSON data to tabular format with comprehensive validation and optimization.
 
@@ -205,23 +211,27 @@ class TableConverter:
         logger.debug(f"Conversion completed: {len(result)} rows")
         return result
 
-    def _convert_single_object(self, data: dict, column_config: dict[str, Any] | None = None) -> TableData:
+    def _convert_single_object(
+        self, data: dict, column_config: dict[str, Any] | None = None
+    ) -> TableData:
         """Convert single object to table format."""
         if not data:
             return []
 
         keys = sorted(data.keys())
-        
+
         # Apply column configuration
         if column_config:
             keys = self._apply_column_config(keys, column_config)
-        
+
         header = keys
         values = [self._safe_str(data.get(key, "")) for key in keys]
 
         return [header, values]
 
-    def _convert_array(self, data: list, column_config: dict[str, Any] | None = None) -> TableData:
+    def _convert_array(
+        self, data: list, column_config: dict[str, Any] | None = None
+    ) -> TableData:
         """Convert array to table format."""
         if not data:
             return []
@@ -232,7 +242,9 @@ class TableConverter:
         else:
             return self._convert_2d_array(data, column_config)
 
-    def _convert_object_array(self, data: list, column_config: dict[str, Any] | None = None) -> TableData:
+    def _convert_object_array(
+        self, data: list, column_config: dict[str, Any] | None = None
+    ) -> TableData:
         """Convert array of objects to table format."""
         if not data:
             return []
@@ -245,7 +257,7 @@ class TableConverter:
 
         # Sort keys for consistent output
         sorted_keys = sorted(all_keys)
-        
+
         # Apply column configuration
         if column_config:
             sorted_keys = self._apply_column_config(sorted_keys, column_config)
@@ -263,7 +275,9 @@ class TableConverter:
 
         return result
 
-    def _convert_2d_array(self, data: list, column_config: dict[str, Any] | None = None) -> TableData:
+    def _convert_2d_array(
+        self, data: list, column_config: dict[str, Any] | None = None
+    ) -> TableData:
         """Convert 2D array to table format."""
         if not data:
             return []
@@ -290,7 +304,9 @@ class TableConverter:
 
         return result
 
-    def _apply_column_config(self, keys: list[str], column_config: dict[str, Any]) -> list[str]:
+    def _apply_column_config(
+        self, keys: list[str], column_config: dict[str, Any]
+    ) -> list[str]:
         """Apply column configuration to column keys for object arrays.
         
         Args:
@@ -328,11 +344,13 @@ class TableConverter:
                     ordered_keys.append(key)
             
             result_keys = ordered_keys
-        
+
         logger.debug(f"Applied column config: {keys} -> {result_keys}")
         return result_keys
     
-    def _apply_column_config_to_2d_array(self, data: TableData, column_config: dict[str, Any]) -> TableData:
+    def _apply_column_config_to_2d_array(
+        self, data: TableData, column_config: dict[str, Any]
+    ) -> TableData:
         """Apply column configuration to 2D array data.
         
         Args:
@@ -387,7 +405,10 @@ class TableConverter:
             filtered_row = [row[i] if i < len(row) else "" for i in column_indices]
             result.append(filtered_row)
         
-        logger.debug(f"Applied column config to 2D array: {len(data[0])} -> {len(result[0])} columns")
+        logger.debug(
+            f"Applied column config to 2D array: {len(data[0])} -> "
+            f"{len(result[0])} columns"
+        )
         return result
     
     def _safe_str(self, value) -> str:

--- a/test_column_customization_manual.py
+++ b/test_column_customization_manual.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""
+Manual test script for column customization features.
+
+This script tests the new column customization functionality without requiring
+the full pytest setup.
+"""
+
+import sys
+import os
+
+# Add the package to the path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'sphinxcontrib'))
+
+def test_column_config_extraction():
+    """Test column configuration extraction."""
+    print("Testing column configuration extraction...")
+    
+    from sphinxcontrib.jsontable.directives.directive_core import JsonTableDirective
+    from unittest.mock import Mock
+    
+    # Create a minimal directive instance
+    directive = JsonTableDirective.__new__(JsonTableDirective)
+    directive.options = {
+        "columns": "name,age,city",
+        "column-order": "city,name,age",
+        "column-widths": "2,1,3",
+        "hide-columns": "id,timestamp"
+    }
+    
+    try:
+        config = directive._extract_column_config()
+        print(f"✓ Column config extracted: {config}")
+        
+        # Verify expected values
+        assert config["visible_columns"] == ["name", "age", "city"]
+        assert config["column_order"] == ["city", "name", "age"]
+        assert config["column_widths"] == [2, 1, 3]
+        assert config["hidden_columns"] == ["id", "timestamp"]
+        print("✓ All config values correct")
+        
+    except Exception as e:
+        print(f"✗ Column config extraction failed: {e}")
+        return False
+    
+    return True
+
+def test_table_converter_column_config():
+    """Test table converter column configuration."""
+    print("\nTesting table converter column configuration...")
+    
+    from sphinxcontrib.jsontable.directives.table_converter import TableConverter
+    
+    try:
+        converter = TableConverter()
+        
+        # Test apply_column_config
+        keys = ["name", "age", "city", "country"]
+        config = {
+            "visible_columns": ["name", "city", "country"],
+            "hidden_columns": ["age"],
+            "column_order": ["country", "name"]
+        }
+        
+        result = converter._apply_column_config(keys, config)
+        expected = ["country", "name", "city"]  # country first, then name, then remaining
+        print(f"✓ Column config applied: {keys} -> {result}")
+        
+        assert result == expected, f"Expected {expected}, got {result}"
+        print("✓ Column ordering correct")
+        
+    except Exception as e:
+        print(f"✗ Table converter column config failed: {e}")
+        return False
+    
+    return True
+
+def test_table_builder_column_widths():
+    """Test table builder column widths."""
+    print("\nTesting table builder column widths...")
+    
+    from sphinxcontrib.jsontable.directives.table_builder import TableBuilder
+    
+    try:
+        builder = TableBuilder()
+        
+        # Test default widths
+        colspecs = builder._create_colspec_nodes(3)
+        assert len(colspecs) == 3
+        assert all(colspec.attributes["colwidth"] == 1 for colspec in colspecs)
+        print("✓ Default column widths correct")
+        
+        # Test custom widths
+        colspecs = builder._create_colspec_nodes(3, [2, 1, 3])
+        assert len(colspecs) == 3
+        assert colspecs[0].attributes["colwidth"] == 2
+        assert colspecs[1].attributes["colwidth"] == 1
+        assert colspecs[2].attributes["colwidth"] == 3
+        print("✓ Custom column widths correct")
+        
+    except Exception as e:
+        print(f"✗ Table builder column widths failed: {e}")
+        return False
+    
+    return True
+
+def test_object_array_conversion():
+    """Test object array conversion with column config."""
+    print("\nTesting object array conversion with column config...")
+    
+    from sphinxcontrib.jsontable.directives.table_converter import TableConverter
+    
+    try:
+        converter = TableConverter()
+        
+        # Test data
+        data = [
+            {"name": "Alice", "age": 25, "city": "Tokyo", "country": "Japan"},
+            {"name": "Bob", "age": 30, "city": "NYC", "country": "USA"}
+        ]
+        
+        # Test with column config
+        column_config = {
+            "visible_columns": ["name", "city", "country"],
+            "column_order": ["country", "city", "name"]
+        }
+        
+        result = converter.convert(data, column_config=column_config)
+        
+        # Expected: header row + 2 data rows
+        assert len(result) == 3
+        assert result[0] == ["country", "city", "name"]  # header in specified order
+        assert result[1] == ["Japan", "Tokyo", "Alice"]
+        assert result[2] == ["USA", "NYC", "Bob"]
+        
+        print("✓ Object array conversion with column config successful")
+        print(f"  Header: {result[0]}")
+        print(f"  Row 1: {result[1]}")
+        print(f"  Row 2: {result[2]}")
+        
+    except Exception as e:
+        print(f"✗ Object array conversion failed: {e}")
+        return False
+    
+    return True
+
+def main():
+    """Run all tests."""
+    print("Column Customization Feature Test Suite")
+    print("=" * 50)
+    
+    tests = [
+        test_column_config_extraction,
+        test_table_converter_column_config,
+        test_table_builder_column_widths,
+        test_object_array_conversion
+    ]
+    
+    passed = 0
+    failed = 0
+    
+    for test in tests:
+        try:
+            if test():
+                passed += 1
+            else:
+                failed += 1
+        except Exception as e:
+            print(f"✗ Test {test.__name__} failed with exception: {e}")
+            failed += 1
+    
+    print("\n" + "=" * 50)
+    print(f"Test Results: {passed} passed, {failed} failed")
+    
+    if failed == 0:
+        print("🎉 All tests passed!")
+        return 0
+    else:
+        print("❌ Some tests failed!")
+        return 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test_column_customization_manual.py
+++ b/test_column_customization_manual.py
@@ -10,13 +10,17 @@ import os
 import sys
 
 # Add the package to the path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'sphinxcontrib'))
+sys.path.insert(
+    0, os.path.join(os.path.dirname(__file__), "sphinxcontrib")
+)
 
 def test_column_config_extraction():
     """Test column configuration extraction."""
     print("Testing column configuration extraction...")
-    
-    from sphinxcontrib.jsontable.directives.directive_core import JsonTableDirective
+
+    from sphinxcontrib.jsontable.directives.directive_core import (
+        JsonTableDirective,
+    )
     
     # Create a minimal directive instance
     directive = JsonTableDirective.__new__(JsonTableDirective)
@@ -24,7 +28,7 @@ def test_column_config_extraction():
         "columns": "name,age,city",
         "column-order": "city,name,age",
         "column-widths": "2,1,3",
-        "hide-columns": "id,timestamp"
+        "hide-columns": "id,timestamp",
     }
     
     try:
@@ -47,8 +51,10 @@ def test_column_config_extraction():
 def test_table_converter_column_config():
     """Test table converter column configuration."""
     print("\nTesting table converter column configuration...")
-    
-    from sphinxcontrib.jsontable.directives.table_converter import TableConverter
+
+    from sphinxcontrib.jsontable.directives.table_converter import (
+        TableConverter,
+    )
     
     try:
         converter = TableConverter()
@@ -62,7 +68,11 @@ def test_table_converter_column_config():
         }
         
         result = converter._apply_column_config(keys, config)
-        expected = ["country", "name", "city"]  # country first, then name, then remaining
+        expected = [
+            "country",
+            "name",
+            "city",
+        ]  # country first, then name, then remaining
         print(f"✓ Column config applied: {keys} -> {result}")
         
         assert result == expected, f"Expected {expected}, got {result}"
@@ -77,8 +87,10 @@ def test_table_converter_column_config():
 def test_table_builder_column_widths():
     """Test table builder column widths."""
     print("\nTesting table builder column widths...")
-    
-    from sphinxcontrib.jsontable.directives.table_builder import TableBuilder
+
+    from sphinxcontrib.jsontable.directives.table_builder import (
+        TableBuilder,
+    )
     
     try:
         builder = TableBuilder()
@@ -106,8 +118,10 @@ def test_table_builder_column_widths():
 def test_object_array_conversion():
     """Test object array conversion with column config."""
     print("\nTesting object array conversion with column config...")
-    
-    from sphinxcontrib.jsontable.directives.table_converter import TableConverter
+
+    from sphinxcontrib.jsontable.directives.table_converter import (
+        TableConverter,
+    )
     
     try:
         converter = TableConverter()
@@ -115,7 +129,7 @@ def test_object_array_conversion():
         # Test data
         data = [
             {"name": "Alice", "age": 25, "city": "Tokyo", "country": "Japan"},
-            {"name": "Bob", "age": 30, "city": "NYC", "country": "USA"}
+            {"name": "Bob", "age": 30, "city": "NYC", "country": "USA"},
         ]
         
         # Test with column config
@@ -128,7 +142,11 @@ def test_object_array_conversion():
         
         # Expected: header row + 2 data rows
         assert len(result) == 3
-        assert result[0] == ["country", "city", "name"]  # header in specified order
+        assert result[0] == [
+            "country",
+            "city",
+            "name",
+        ]  # header in specified order
         assert result[1] == ["Japan", "Tokyo", "Alice"]
         assert result[2] == ["USA", "NYC", "Bob"]
         
@@ -152,7 +170,7 @@ def main():
         test_column_config_extraction,
         test_table_converter_column_config,
         test_table_builder_column_widths,
-        test_object_array_conversion
+        test_object_array_conversion,
     ]
     
     passed = 0

--- a/test_column_customization_manual.py
+++ b/test_column_customization_manual.py
@@ -28,7 +28,7 @@ def test_column_config_extraction():
         "column-widths": "2,1,3",
         "hide-columns": "id,timestamp",
     }
-    
+
     try:
         config = directive._extract_column_config()
         print(f"✓ Column config extracted: {config}")
@@ -39,11 +39,11 @@ def test_column_config_extraction():
         assert config["column_widths"] == [2, 1, 3]
         assert config["hidden_columns"] == ["id", "timestamp"]
         print("✓ All config values correct")
-        
+
     except Exception as e:
         print(f"✗ Column config extraction failed: {e}")
         return False
-    
+
     return True
 
 def test_table_converter_column_config():
@@ -53,10 +53,10 @@ def test_table_converter_column_config():
     from sphinxcontrib.jsontable.directives.table_converter import (
         TableConverter,
     )
-    
+
     try:
         converter = TableConverter()
-        
+
         # Test apply_column_config
         keys = ["name", "age", "city", "country"]
         config = {
@@ -122,24 +122,24 @@ def test_object_array_conversion():
     from sphinxcontrib.jsontable.directives.table_converter import (
         TableConverter,
     )
-    
+
     try:
         converter = TableConverter()
-        
+
         # Test data
         data = [
             {"name": "Alice", "age": 25, "city": "Tokyo", "country": "Japan"},
             {"name": "Bob", "age": 30, "city": "NYC", "country": "USA"},
         ]
-        
+
         # Test with column config
         column_config = {
             "visible_columns": ["name", "city", "country"],
             "column_order": ["country", "city", "name"]
         }
-        
+
         result = converter.convert(data, column_config=column_config)
-        
+
         # Expected: header row + 2 data rows
         assert len(result) == 3
         assert result[0] == [
@@ -149,33 +149,33 @@ def test_object_array_conversion():
         ]  # header in specified order
         assert result[1] == ["Japan", "Tokyo", "Alice"]
         assert result[2] == ["USA", "NYC", "Bob"]
-        
+
         print("✓ Object array conversion with column config successful")
         print(f"  Header: {result[0]}")
         print(f"  Row 1: {result[1]}")
         print(f"  Row 2: {result[2]}")
-        
+
     except Exception as e:
         print(f"✗ Object array conversion failed: {e}")
         return False
-    
+
     return True
 
 def main():
     """Run all tests."""
     print("Column Customization Feature Test Suite")
     print("=" * 50)
-    
+
     tests = [
         test_column_config_extraction,
         test_table_converter_column_config,
         test_table_builder_column_widths,
         test_object_array_conversion,
     ]
-    
+
     passed = 0
     failed = 0
-    
+
     for test in tests:
         try:
             if test():
@@ -185,10 +185,10 @@ def main():
         except Exception as e:
             print(f"✗ Test {test.__name__} failed with exception: {e}")
             failed += 1
-    
+
     print("\n" + "=" * 50)
     print(f"Test Results: {passed} passed, {failed} failed")
-    
+
     if failed == 0:
         print("🎉 All tests passed!")
         return 0

--- a/test_column_customization_manual.py
+++ b/test_column_customization_manual.py
@@ -10,9 +10,7 @@ import os
 import sys
 
 # Add the package to the path
-sys.path.insert(
-    0, os.path.join(os.path.dirname(__file__), "sphinxcontrib")
-)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "sphinxcontrib"))
 
 def test_column_config_extraction():
     """Test column configuration extraction."""
@@ -21,7 +19,7 @@ def test_column_config_extraction():
     from sphinxcontrib.jsontable.directives.directive_core import (
         JsonTableDirective,
     )
-    
+
     # Create a minimal directive instance
     directive = JsonTableDirective.__new__(JsonTableDirective)
     directive.options = {
@@ -34,7 +32,7 @@ def test_column_config_extraction():
     try:
         config = directive._extract_column_config()
         print(f"✓ Column config extracted: {config}")
-        
+
         # Verify expected values
         assert config["visible_columns"] == ["name", "age", "city"]
         assert config["column_order"] == ["city", "name", "age"]
@@ -64,9 +62,9 @@ def test_table_converter_column_config():
         config = {
             "visible_columns": ["name", "city", "country"],
             "hidden_columns": ["age"],
-            "column_order": ["country", "name"]
+            "column_order": ["country", "name"],
         }
-        
+
         result = converter._apply_column_config(keys, config)
         expected = [
             "country",
@@ -74,15 +72,16 @@ def test_table_converter_column_config():
             "city",
         ]  # country first, then name, then remaining
         print(f"✓ Column config applied: {keys} -> {result}")
-        
+
         assert result == expected, f"Expected {expected}, got {result}"
         print("✓ Column ordering correct")
-        
+
     except Exception as e:
         print(f"✗ Table converter column config failed: {e}")
         return False
-    
+
     return True
+
 
 def test_table_builder_column_widths():
     """Test table builder column widths."""
@@ -91,16 +90,16 @@ def test_table_builder_column_widths():
     from sphinxcontrib.jsontable.directives.table_builder import (
         TableBuilder,
     )
-    
+
     try:
         builder = TableBuilder()
-        
+
         # Test default widths
         colspecs = builder._create_colspec_nodes(3)
         assert len(colspecs) == 3
         assert all(colspec.attributes["colwidth"] == 1 for colspec in colspecs)
         print("✓ Default column widths correct")
-        
+
         # Test custom widths
         colspecs = builder._create_colspec_nodes(3, [2, 1, 3])
         assert len(colspecs) == 3
@@ -108,12 +107,13 @@ def test_table_builder_column_widths():
         assert colspecs[1].attributes["colwidth"] == 1
         assert colspecs[2].attributes["colwidth"] == 3
         print("✓ Custom column widths correct")
-        
+
     except Exception as e:
         print(f"✗ Table builder column widths failed: {e}")
         return False
-    
+
     return True
+
 
 def test_object_array_conversion():
     """Test object array conversion with column config."""

--- a/test_column_customization_manual.py
+++ b/test_column_customization_manual.py
@@ -6,8 +6,8 @@ This script tests the new column customization functionality without requiring
 the full pytest setup.
 """
 
-import sys
 import os
+import sys
 
 # Add the package to the path
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'sphinxcontrib'))
@@ -17,7 +17,6 @@ def test_column_config_extraction():
     print("Testing column configuration extraction...")
     
     from sphinxcontrib.jsontable.directives.directive_core import JsonTableDirective
-    from unittest.mock import Mock
     
     # Create a minimal directive instance
     directive = JsonTableDirective.__new__(JsonTableDirective)

--- a/tests/test_column_customization.py
+++ b/tests/test_column_customization.py
@@ -1,0 +1,200 @@
+"""
+Test cases for column customization features (Issue #48).
+
+This module tests the new column customization functionality including:
+- columns: Specify visible columns
+- column-order: Define column order  
+- column-widths: Set column widths
+- hide-columns: Hide specific columns
+"""
+
+import pytest
+from unittest.mock import Mock, patch
+
+from sphinxcontrib.jsontable.directives import JsonTableDirective
+
+
+class TestColumnCustomization:
+    """Test suite for column customization features."""
+
+    @pytest.fixture
+    def mock_state(self):
+        """Create a mock state with document and environment."""
+        state = Mock()
+        state.document = Mock()
+        state.document.settings = Mock()
+        state.document.settings.env = Mock()
+        state.document.settings.env.srcdir = "/mock/source/dir"
+        return state
+
+    @pytest.fixture
+    def directive_instance(self, mock_state):
+        """Create a JsonTableDirective instance for testing."""
+        with patch("sphinx.util.docutils.SphinxDirective.__init__"), patch(
+            "sphinxcontrib.jsontable.directives.JsonDataLoader"
+        ), patch(
+            "sphinxcontrib.jsontable.directives.TableConverter"
+        ), patch(
+            "sphinxcontrib.jsontable.directives.TableBuilder"
+        ):
+            directive = JsonTableDirective.__new__(JsonTableDirective)
+            directive.state = mock_state
+            directive.arguments = []
+            directive.content = []
+            directive.options = {}
+            directive.env = mock_state.document.settings.env
+            return directive
+
+    def test_extract_column_config_empty(self, directive_instance):
+        """Test column config extraction with no options."""
+        directive_instance.options = {}
+        config = directive_instance._extract_column_config()
+        assert config == {}
+
+    def test_extract_column_config_columns(self, directive_instance):
+        """Test column config extraction with columns option."""
+        directive_instance.options = {"columns": "name,age,city"}
+        config = directive_instance._extract_column_config()
+        assert config["visible_columns"] == ["name", "age", "city"]
+
+    def test_extract_column_config_column_order(self, directive_instance):
+        """Test column config extraction with column-order option."""
+        directive_instance.options = {"column-order": "city,name,age"}
+        config = directive_instance._extract_column_config()
+        assert config["column_order"] == ["city", "name", "age"]
+
+    def test_extract_column_config_column_widths(self, directive_instance):
+        """Test column config extraction with column-widths option."""
+        directive_instance.options = {"column-widths": "2,1,3"}
+        config = directive_instance._extract_column_config()
+        assert config["column_widths"] == [2, 1, 3]
+
+    def test_extract_column_config_hide_columns(self, directive_instance):
+        """Test column config extraction with hide-columns option."""
+        directive_instance.options = {"hide-columns": "id,timestamp"}
+        config = directive_instance._extract_column_config()
+        assert config["hidden_columns"] == ["id", "timestamp"]
+
+    def test_extract_column_config_invalid_widths(self, directive_instance):
+        """Test column config extraction with invalid column-widths."""
+        directive_instance.options = {"column-widths": "2,invalid,3"}
+        config = directive_instance._extract_column_config()
+        # Should not include column_widths due to ValueError
+        assert "column_widths" not in config
+
+    def test_extract_column_config_with_spaces(self, directive_instance):
+        """Test column config extraction with spaces in values."""
+        directive_instance.options = {
+            "columns": " name , age , city ",
+            "column-order": " city , name , age "
+        }
+        config = directive_instance._extract_column_config()
+        assert config["visible_columns"] == ["name", "age", "city"]
+        assert config["column_order"] == ["city", "name", "age"]
+
+    def test_extract_column_config_all_options(self, directive_instance):
+        """Test column config extraction with all options."""
+        directive_instance.options = {
+            "columns": "name,age,city,country",
+            "column-order": "country,city,name",
+            "column-widths": "2,3,1",
+            "hide-columns": "age"
+        }
+        config = directive_instance._extract_column_config()
+        assert config["visible_columns"] == ["name", "age", "city", "country"]
+        assert config["column_order"] == ["country", "city", "name"]
+        assert config["column_widths"] == [2, 3, 1]
+        assert config["hidden_columns"] == ["age"]
+
+
+class TestTableConverterColumnConfig:
+    """Test suite for TableConverter column configuration methods."""
+    
+    def test_apply_column_config_visible_columns(self):
+        """Test apply_column_config with visible_columns filter."""
+        from sphinxcontrib.jsontable.directives.table_converter import TableConverter
+        
+        converter = TableConverter()
+        keys = ["name", "age", "city", "country"]
+        config = {"visible_columns": ["name", "city"]}
+        
+        result = converter._apply_column_config(keys, config)
+        assert result == ["name", "city"]
+
+    def test_apply_column_config_hidden_columns(self):
+        """Test apply_column_config with hidden_columns filter."""
+        from sphinxcontrib.jsontable.directives.table_converter import TableConverter
+        
+        converter = TableConverter()
+        keys = ["name", "age", "city", "country"]
+        config = {"hidden_columns": ["age", "country"]}
+        
+        result = converter._apply_column_config(keys, config)
+        assert result == ["city", "name"]  # remaining columns, sorted
+
+    def test_apply_column_config_column_order(self):
+        """Test apply_column_config with column_order."""
+        from sphinxcontrib.jsontable.directives.table_converter import TableConverter
+        
+        converter = TableConverter()
+        keys = ["name", "age", "city", "country"]
+        config = {"column_order": ["country", "name", "city"]}
+        
+        result = converter._apply_column_config(keys, config)
+        assert result == ["country", "name", "city", "age"]  # ordered + remaining
+
+    def test_apply_column_config_combined(self):
+        """Test apply_column_config with multiple filters."""
+        from sphinxcontrib.jsontable.directives.table_converter import TableConverter
+        
+        converter = TableConverter()
+        keys = ["name", "age", "city", "country", "id"]
+        config = {
+            "visible_columns": ["name", "age", "city", "country"],
+            "hidden_columns": ["age"],
+            "column_order": ["country", "name"]
+        }
+        
+        result = converter._apply_column_config(keys, config)
+        # Should have: visible(name,age,city,country) - hidden(age) = name,city,country
+        # Ordered as: country, name, city
+        assert result == ["country", "name", "city"]
+
+
+class TestTableBuilderColumnWidths:
+    """Test suite for TableBuilder column width functionality."""
+    
+    def test_create_colspec_nodes_default_widths(self):
+        """Test colspec creation with default widths."""
+        from sphinxcontrib.jsontable.directives.table_builder import TableBuilder
+        
+        builder = TableBuilder()
+        colspecs = builder._create_colspec_nodes(3)
+        
+        assert len(colspecs) == 3
+        assert all(colspec.attributes["colwidth"] == 1 for colspec in colspecs)
+
+    def test_create_colspec_nodes_custom_widths(self):
+        """Test colspec creation with custom widths."""
+        from sphinxcontrib.jsontable.directives.table_builder import TableBuilder
+        
+        builder = TableBuilder()
+        colspecs = builder._create_colspec_nodes(3, [2, 1, 3])
+        
+        assert len(colspecs) == 3
+        assert colspecs[0].attributes["colwidth"] == 2
+        assert colspecs[1].attributes["colwidth"] == 1
+        assert colspecs[2].attributes["colwidth"] == 3
+
+    def test_create_colspec_nodes_partial_widths(self):
+        """Test colspec creation with fewer widths than columns."""
+        from sphinxcontrib.jsontable.directives.table_builder import TableBuilder
+        
+        builder = TableBuilder()
+        colspecs = builder._create_colspec_nodes(4, [2, 3])
+        
+        assert len(colspecs) == 4
+        assert colspecs[0].attributes["colwidth"] == 2
+        assert colspecs[1].attributes["colwidth"] == 3
+        assert colspecs[2].attributes["colwidth"] == 1  # default
+        assert colspecs[3].attributes["colwidth"] == 1  # default

--- a/tests/test_column_customization.py
+++ b/tests/test_column_customization.py
@@ -110,17 +110,17 @@ class TestColumnCustomization:
 
 class TestTableConverterColumnConfig:
     """Test suite for TableConverter column configuration methods."""
-    
+
     def test_apply_column_config_visible_columns(self):
         """Test apply_column_config with visible_columns filter."""
         from sphinxcontrib.jsontable.directives.table_converter import (
             TableConverter,
         )
-        
+
         converter = TableConverter()
         keys = ["name", "age", "city", "country"]
         config = {"visible_columns": ["name", "city"]}
-        
+
         result = converter._apply_column_config(keys, config)
         assert result == ["name", "city"]
 
@@ -129,11 +129,11 @@ class TestTableConverterColumnConfig:
         from sphinxcontrib.jsontable.directives.table_converter import (
             TableConverter,
         )
-        
+
         converter = TableConverter()
         keys = ["name", "age", "city", "country"]
         config = {"hidden_columns": ["age", "country"]}
-        
+
         result = converter._apply_column_config(keys, config)
         assert result == ["city", "name"]  # remaining columns, sorted
 
@@ -142,11 +142,11 @@ class TestTableConverterColumnConfig:
         from sphinxcontrib.jsontable.directives.table_converter import (
             TableConverter,
         )
-        
+
         converter = TableConverter()
         keys = ["name", "age", "city", "country"]
         config = {"column_order": ["country", "name", "city"]}
-        
+
         result = converter._apply_column_config(keys, config)
         assert result == [
             "country",
@@ -160,7 +160,7 @@ class TestTableConverterColumnConfig:
         from sphinxcontrib.jsontable.directives.table_converter import (
             TableConverter,
         )
-        
+
         converter = TableConverter()
         keys = ["name", "age", "city", "country", "id"]
         config = {
@@ -168,25 +168,25 @@ class TestTableConverterColumnConfig:
             "hidden_columns": ["age"],
             "column_order": ["country", "name"]
         }
-        
+
         result = converter._apply_column_config(keys, config)
-        # Should have: visible(name,age,city,country) - hidden(age) = name,city,country  # noqa: E501
+        # Should have: visible(name,age,city,country) - hidden(age) = name,city,country
         # Ordered as: country, name, city
         assert result == ["country", "name", "city"]
 
 
 class TestTableBuilderColumnWidths:
     """Test suite for TableBuilder column width functionality."""
-    
+
     def test_create_colspec_nodes_default_widths(self):
         """Test colspec creation with default widths."""
         from sphinxcontrib.jsontable.directives.table_builder import (
             TableBuilder,
         )
-        
+
         builder = TableBuilder()
         colspecs = builder._create_colspec_nodes(3)
-        
+
         assert len(colspecs) == 3
         assert all(colspec.attributes["colwidth"] == 1 for colspec in colspecs)
 
@@ -195,10 +195,10 @@ class TestTableBuilderColumnWidths:
         from sphinxcontrib.jsontable.directives.table_builder import (
             TableBuilder,
         )
-        
+
         builder = TableBuilder()
         colspecs = builder._create_colspec_nodes(3, [2, 1, 3])
-        
+
         assert len(colspecs) == 3
         assert colspecs[0].attributes["colwidth"] == 2
         assert colspecs[1].attributes["colwidth"] == 1
@@ -209,10 +209,10 @@ class TestTableBuilderColumnWidths:
         from sphinxcontrib.jsontable.directives.table_builder import (
             TableBuilder,
         )
-        
+
         builder = TableBuilder()
         colspecs = builder._create_colspec_nodes(4, [2, 3])
-        
+
         assert len(colspecs) == 4
         assert colspecs[0].attributes["colwidth"] == 2
         assert colspecs[1].attributes["colwidth"] == 3

--- a/tests/test_column_customization.py
+++ b/tests/test_column_customization.py
@@ -3,7 +3,7 @@ Test cases for column customization features (Issue #48).
 
 This module tests the new column customization functionality including:
 - columns: Specify visible columns
-- column-order: Define column order  
+- column-order: Define column order
 - column-widths: Set column widths
 - hide-columns: Hide specific columns
 """
@@ -113,7 +113,9 @@ class TestTableConverterColumnConfig:
     
     def test_apply_column_config_visible_columns(self):
         """Test apply_column_config with visible_columns filter."""
-        from sphinxcontrib.jsontable.directives.table_converter import TableConverter
+        from sphinxcontrib.jsontable.directives.table_converter import (
+            TableConverter,
+        )
         
         converter = TableConverter()
         keys = ["name", "age", "city", "country"]
@@ -124,7 +126,9 @@ class TestTableConverterColumnConfig:
 
     def test_apply_column_config_hidden_columns(self):
         """Test apply_column_config with hidden_columns filter."""
-        from sphinxcontrib.jsontable.directives.table_converter import TableConverter
+        from sphinxcontrib.jsontable.directives.table_converter import (
+            TableConverter,
+        )
         
         converter = TableConverter()
         keys = ["name", "age", "city", "country"]
@@ -135,18 +139,27 @@ class TestTableConverterColumnConfig:
 
     def test_apply_column_config_column_order(self):
         """Test apply_column_config with column_order."""
-        from sphinxcontrib.jsontable.directives.table_converter import TableConverter
+        from sphinxcontrib.jsontable.directives.table_converter import (
+            TableConverter,
+        )
         
         converter = TableConverter()
         keys = ["name", "age", "city", "country"]
         config = {"column_order": ["country", "name", "city"]}
         
         result = converter._apply_column_config(keys, config)
-        assert result == ["country", "name", "city", "age"]  # ordered + remaining
+        assert result == [
+            "country",
+            "name",
+            "city",
+            "age",
+        ]  # ordered + remaining
 
     def test_apply_column_config_combined(self):
         """Test apply_column_config with multiple filters."""
-        from sphinxcontrib.jsontable.directives.table_converter import TableConverter
+        from sphinxcontrib.jsontable.directives.table_converter import (
+            TableConverter,
+        )
         
         converter = TableConverter()
         keys = ["name", "age", "city", "country", "id"]
@@ -157,7 +170,7 @@ class TestTableConverterColumnConfig:
         }
         
         result = converter._apply_column_config(keys, config)
-        # Should have: visible(name,age,city,country) - hidden(age) = name,city,country
+        # Should have: visible(name,age,city,country) - hidden(age) = name,city,country  # noqa: E501
         # Ordered as: country, name, city
         assert result == ["country", "name", "city"]
 
@@ -167,7 +180,9 @@ class TestTableBuilderColumnWidths:
     
     def test_create_colspec_nodes_default_widths(self):
         """Test colspec creation with default widths."""
-        from sphinxcontrib.jsontable.directives.table_builder import TableBuilder
+        from sphinxcontrib.jsontable.directives.table_builder import (
+            TableBuilder,
+        )
         
         builder = TableBuilder()
         colspecs = builder._create_colspec_nodes(3)
@@ -177,7 +192,9 @@ class TestTableBuilderColumnWidths:
 
     def test_create_colspec_nodes_custom_widths(self):
         """Test colspec creation with custom widths."""
-        from sphinxcontrib.jsontable.directives.table_builder import TableBuilder
+        from sphinxcontrib.jsontable.directives.table_builder import (
+            TableBuilder,
+        )
         
         builder = TableBuilder()
         colspecs = builder._create_colspec_nodes(3, [2, 1, 3])
@@ -189,7 +206,9 @@ class TestTableBuilderColumnWidths:
 
     def test_create_colspec_nodes_partial_widths(self):
         """Test colspec creation with fewer widths than columns."""
-        from sphinxcontrib.jsontable.directives.table_builder import TableBuilder
+        from sphinxcontrib.jsontable.directives.table_builder import (
+            TableBuilder,
+        )
         
         builder = TableBuilder()
         colspecs = builder._create_colspec_nodes(4, [2, 3])

--- a/tests/test_column_customization.py
+++ b/tests/test_column_customization.py
@@ -8,8 +8,9 @@ This module tests the new column customization functionality including:
 - hide-columns: Hide specific columns
 """
 
-import pytest
 from unittest.mock import Mock, patch
+
+import pytest
 
 from sphinxcontrib.jsontable.directives import JsonTableDirective
 


### PR DESCRIPTION
Add comprehensive column customization options to jsontable directive:
- columns: Specify visible columns (comma-separated)
- column-order: Define custom column order (comma-separated)
- column-widths: Set column width ratios (comma-separated integers)
- hide-columns: Hide specific columns (comma-separated)

Key improvements:
- Support for all data formats (object arrays, 2D arrays, single objects)
- Smart column filtering with priority-based application
- Backward compatibility maintained for existing functionality
- Custom column width support in table rendering
- Comprehensive test coverage and documentation

Files modified:
- directive_core.py: Added new options and configuration parsing
- table_converter.py: Enhanced with column filtering and ordering
- table_builder.py: Added custom column width support
- README.md: Updated documentation with new features

Files added:
- tests/test_column_customization.py: Comprehensive test suite
- examples/column_customization_examples.rst: Usage examples
- test_column_customization_manual.py: Manual validation script

🤖 Generated with [Claude Code](https://claude.ai/code)